### PR TITLE
[Doc] Fix formatting and bump to v3.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 3.0.5
-  - Fix formatting in doc for conversion to --asciidoctor [#tbd](https://github.com/logstash-plugins/logstash-output-riak/pull/tbd)
+  - Fix formatting in doc for conversion to --asciidoctor [#4](https://github.com/logstash-plugins/logstash-output-riak/pull/4)
 
 ## 3.0.4
   - Docs: Set the default_codec doc attribute.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.5
+  - Fix formatting in doc for conversion to --asciidoctor [#tbd](https://github.com/logstash-plugins/logstash-output-riak/pull/tbd)
+
 ## 3.0.4
   - Docs: Set the default_codec doc attribute.
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -70,15 +70,23 @@ apply to ALL the buckets.
 Bucket properties (NYI)
 Logstash hash of properties for the bucket
 i.e.
+
 [source,ruby]
+-----
     bucket_props => {
         "r" => "one"
         "w" => "one"
         "dw", "one
      }
+-----
+
 or
+
 [source,ruby]
+-----
     bucket_props => { "n_val" => "3" }
+-----
+
 Properties will be passed as-is
 
 [id="plugins-{type}s-{plugin}-enable_search"]
@@ -108,8 +116,12 @@ Enable SSL
 Indices
 Array of fields to add 2i on
 e.g.
+
 [source,ruby]
+-----
     `indices => ["source_host", "type"]
+-----
+
 Off by default as not everyone runs eleveldb
 
 [id="plugins-{type}s-{plugin}-key_name"]
@@ -133,11 +145,14 @@ The nodes of your Riak cluster
 This can be a single host or
 a Logstash hash of node/port pairs
 e.g
+
 [source,ruby]
+-----
     {
         "node1" => "8098"
         "node2" => "8098"
     }
+-----
 
 [id="plugins-{type}s-{plugin}-proto"]
 ===== `proto` 
@@ -156,18 +171,20 @@ No mix and match
   * Value type is <<hash,hash>>
   * There is no default value for this setting.
 
-SSL Options
-Options for SSL connections
-Only applied if SSL is enabled
+Options for SSL connections.
+Only applied if SSL is enabled.
 Logstash hash that maps to the riak-client options
-here: https://github.com/basho/riak-ruby-client/wiki/Connecting-to-Riak
+here: https://github.com/basho/riak-ruby-client/wiki/Connecting-to-Riak.
+
 You'll likely want something like this:
 
 [source, ruby]
+-----
     ssl_opts => {
        "pem" => "/etc/riak.pem"
        "ca_path" => "/usr/share/certificates"
     }
+-----
 
 Per the riak client docs, the above sample options
 will turn on SSL `VERIFY_PEER`

--- a/logstash-output-riak.gemspec
+++ b/logstash-output-riak.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-riak'
-  s.version         = '3.0.4'
+  s.version         = '3.0.5'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Writes events to the Riak distributed key/value store"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Fix asciidoc formatting in code samples in preparation for move to --asciidoctor

